### PR TITLE
fix: register_modal

### DIFF
--- a/src/components/registerModal.tsx
+++ b/src/components/registerModal.tsx
@@ -45,7 +45,7 @@ const ModalHeader = styled.section`
   height: 50px;
   display: flex;
   flex-direction: row;
-  align-items: end;
+  align-items: flex-end;
   padding-bottom: 4px;
   box-sizing: border-box;
   width: 100%;
@@ -332,7 +332,7 @@ function ModalContent ({item, setOpen, type}: {item: Item, setOpen(flag: boolean
               footer = {
                 <>
                   {type === "장소" &&
-                        <Link to="/accessibility" style={{pointerEvents: checkFillInfo(place) ? 'auto' : 'none'}}><RegisterModalBtn active={checkFillInfo(place)}  onClick={() => updateInfo(place)}>등록하기</RegisterModalBtn></Link>
+                        <Link to="/register_complete" style={{pointerEvents: checkFillInfo(place) ? 'auto' : 'none'}}><RegisterModalBtn active={checkFillInfo(place)}  onClick={() => updateInfo(place)}>등록하기</RegisterModalBtn></Link>
                   }
                   {type !== "장소" &&
                     <>


### PR DESCRIPTION
## 개요
<!-- 어떤 기능에 대해서 PR을 남겼는지 기입 -->
- align-items 속성 수정
- 장소 정보만 입력시 바로 조회 페이로 가는 문제 수정

## 변경 사항
<!-- 코드의 변경사항 기입
- [항목] 내용
-->
- 접근성 등록 모달에서 화살표의 `align-items`의 속성이 `end`로 되어 있어 문제감 됨 따라서 이부분을 `flex-end`로 수정
- 장소 정보만 입력할 경우 페이지 이동이 등록 완료 페이지로 가야 하나, 조회 페이지로 가게 되어 문제가 됨 따라서 이를 수정함